### PR TITLE
chore(*) use `tokio-tun` v0.5 instead of forked version

### DIFF
--- a/fake-tcp/Cargo.toml
+++ b/fake-tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fake-tcp"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Datong Sun <dndx@idndx.com>"]
 license = "MIT OR Apache-2.0"
@@ -21,4 +21,4 @@ tokio = { version = "1.14", features = ["full"] }
 rand = { version = "0.8", features = ["small_rng"] }
 log = "0.4"
 internet-checksum = "0.2"
-dndx-fork-tokio-tun = "0.4"
+tokio-tun = "0.5"

--- a/fake-tcp/src/lib.rs
+++ b/fake-tcp/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature = "benchmark", feature(test))]
 
 pub mod packet;
-extern crate dndx_fork_tokio_tun as tokio_tun;
 
 use bytes::{Bytes, BytesMut};
 use log::{error, info, trace, warn};

--- a/phantun/Cargo.toml
+++ b/phantun/Cargo.toml
@@ -13,9 +13,9 @@ Layer 3 & Layer 4 (NAPT) firewalls/NATs.
 [dependencies]
 clap = "2.34"
 socket2 = { version = "0.4", features = ["all"] }
-fake-tcp = "0.2.2"
+fake-tcp = "0.2"
 tokio = { version = "1.14", features = ["full"] }
 log = "0.4"
 pretty_env_logger = "0.4"
-dndx-fork-tokio-tun = "0.4"
+tokio-tun = "0.5"
 num_cpus = "1.13"

--- a/phantun/src/bin/client.rs
+++ b/phantun/src/bin/client.rs
@@ -1,5 +1,3 @@
-extern crate dndx_fork_tokio_tun as tokio_tun;
-
 use clap::{crate_version, App, Arg};
 use fake_tcp::packet::MAX_PACKET_LEN;
 use fake_tcp::{Socket, Stack};

--- a/phantun/src/bin/server.rs
+++ b/phantun/src/bin/server.rs
@@ -1,5 +1,3 @@
-extern crate dndx_fork_tokio_tun as tokio_tun;
-
 use clap::{crate_version, App, Arg};
 use fake_tcp::packet::MAX_PACKET_LEN;
 use fake_tcp::Stack;


### PR DESCRIPTION
Forked version no longer needed as https://github.com/yaa110/tokio-tun/pull/4 is merged now!