### PR TITLE
fix(fake-tcp) fix an issue where `RST` generated is not following the…

### DIFF
--- a/phantun/src/bin/client.rs
+++ b/phantun/src/bin/client.rs
@@ -99,6 +99,7 @@ async fn main() {
         .expect("bad peer address for Tun interface");
 
     let num_cpus = num_cpus::get();
+    info!("{} cores available", num_cpus);
 
     let tun = TunBuilder::new()
         .name(matches.value_of("tun").unwrap()) // if name is empty, then it is set by kernel.
@@ -157,7 +158,7 @@ async fn main() {
 
                     for i in 0..num_cpus {
                         let sock = sock.clone();
-                        let quit = quit.child_token();
+                        let quit = quit.clone();
                         let packet_received = packet_received.clone();
 
                         tokio::spawn(async move {

--- a/phantun/src/bin/server.rs
+++ b/phantun/src/bin/server.rs
@@ -94,6 +94,7 @@ async fn main() {
         .expect("bad peer address for Tun interface");
 
     let num_cpus = num_cpus::get();
+    info!("{} cores available", num_cpus);
 
     let tun = TunBuilder::new()
         .name(matches.value_of("tun").unwrap()) // if name is empty, then it is set by kernel.
@@ -134,7 +135,7 @@ async fn main() {
 
             for i in 0..num_cpus {
                 let sock = sock.clone();
-                let quit = quit.child_token();
+                let quit = quit.clone();
                 let packet_received = packet_received.clone();
                 let udp_sock = new_udp_reuseport(local_addr);
 


### PR DESCRIPTION
fix(fake-tcp) fix an issue where RST generated is not following the proper RFC requirement.

Send ACK every 128MB in lieu of data packets.

Now Phantun no longer causes `nf_conntrack` to report invalid packets.