### PR TITLE
Let the memory allocator zero initialize the memory

### DIFF
--- a/fake-tcp/Cargo.toml
+++ b/fake-tcp/Cargo.toml
@@ -15,7 +15,7 @@ packet oriented tunneling with minimum overhead.
 benchmark = []
 
 [dependencies]
-bytes = "1.2"
+bytes = "1"
 pnet = "0.31"
 tokio = { version = "1.14", features = ["full"] }
 rand = { version = "0.8", features = ["small_rng"] }

--- a/fake-tcp/Cargo.toml
+++ b/fake-tcp/Cargo.toml
@@ -15,7 +15,7 @@ packet oriented tunneling with minimum overhead.
 benchmark = []
 
 [dependencies]
-bytes = "1"
+bytes = "1.2"
 pnet = "0.31"
 tokio = { version = "1.14", features = ["full"] }
 rand = { version = "0.8", features = ["small_rng"] }

--- a/fake-tcp/src/lib.rs
+++ b/fake-tcp/src/lib.rs
@@ -436,8 +436,7 @@ impl Stack {
         let mut tuples: HashMap<AddrTuple, flume::Sender<Bytes>> = HashMap::new();
 
         loop {
-            let mut buf = BytesMut::with_capacity(MAX_PACKET_LEN);
-            buf.resize(MAX_PACKET_LEN, 0);
+            let mut buf = BytesMut::zeroed(MAX_PACKET_LEN);
 
             tokio::select! {
                 size = tun.recv(&mut buf) => {

--- a/fake-tcp/src/packet.rs
+++ b/fake-tcp/src/packet.rs
@@ -47,8 +47,7 @@ pub fn build_tcp_packet(
     let tcp_header_len = TCP_HEADER_LEN + if wscale { 4 } else { 0 }; // nop + wscale
     let tcp_total_len = tcp_header_len + payload.map_or(0, |payload| payload.len());
     let total_len = ip_header_len + tcp_total_len;
-    let mut buf = BytesMut::with_capacity(total_len);
-    buf.resize(total_len, 0);
+    let mut buf = BytesMut::zeroed(total_len);
 
     let mut ip_buf = buf.split_to(ip_header_len);
     let mut tcp_buf = buf.split_to(tcp_total_len);


### PR DESCRIPTION
Basically the same as changing

```rust
let mut vec = Vec::with_capacity(capacity);
vec.resize(capacity, 0);
```

to

```rust
let mut vec = vec![0; capacity];
```

which is usually faster