### PR TITLE
chore(docker): use Debian as base image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,30 +5,22 @@
 #
 # Build stage
 #
-FROM rust:alpine AS builder
+FROM rust:latest AS builder
 
 COPY . /phantun
 
-RUN apk update \
-  && apk add --no-cache --virtual .build-deps musl-dev \
-  && cd phantun \
+RUN cd phantun \
   && cargo build --release \
   && strip target/release/server target/release/client \
   && install target/release/server /usr/local/bin/phantun-server \
   && install target/release/client /usr/local/bin/phantun-client \
   && cd - \
-  && rm -r phantun \
-  && apk del .build-deps \
-  && rm -rf /var/cache/apk/*
+  && rm -r phantun
 
 #
 # Runtime stage
 #
-FROM alpine:3.16
-
-RUN apk update \
-  && apk add --no-cache iptables ip6tables tzdata \
-  && rm -rf /var/cache/apk/*
+FROM debian:latest
 
 COPY --from=builder /usr/local/bin/phantun-server /usr/local/bin/
 COPY --from=builder /usr/local/bin/phantun-client /usr/local/bin/


### PR DESCRIPTION
Alpine has worse performance and musl does not work well with Rust `libc` version `3`, use Debian instead.