### PR TITLE
Add IP4P domain resolve support

### DIFF
--- a/phantun/Cargo.toml
+++ b/phantun/Cargo.toml
@@ -22,3 +22,4 @@ tokio-tun = "0.11"
 num_cpus = "1.13"
 neli = "0.6"
 nix = { version = "0.28", features = ["net"] }
+dns-lookup = "2.0.4"

--- a/phantun/src/utils.rs
+++ b/phantun/src/utils.rs
@@ -9,7 +9,7 @@ use neli::{
     socket::NlSocketHandle,
     types::RtBuffer,
 };
-use std::net::{Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 
 pub fn new_udp_reuseport(local_addr: SocketAddr) -> UdpSocket {
@@ -57,4 +57,38 @@ pub fn assign_ipv6_address(device_name: &str, local: Ipv6Addr, peer: Ipv6Addr) {
         NlPayload::Payload(ifaddrmsg),
     );
     rtnl.send(nl_header).unwrap();
+}
+
+pub async fn lookup_host(domain: &str, ip4p_resolve: bool, ipv4_only: bool) -> std::net::SocketAddr {
+    if ip4p_resolve {
+        return resolve_ip4p_domain(domain);
+    }
+    return tokio::net::lookup_host(domain)
+        .await
+        .expect("bad remote address or host")
+        .find(|addr| !ipv4_only || addr.is_ipv4())
+        .expect("unable to resolve remote host name");
+}
+
+fn resolve_ip4p_domain(domain: &str) -> std::net::SocketAddr {
+    let ip4p_addr = dns_lookup::lookup_host(domain).unwrap();
+    let ip4p_addr = ip4p_addr[0].to_string();
+    let ip4p_resolve: Vec<&str> = ip4p_addr.split(':').collect();
+    if ip4p_resolve.len() != 5 {
+        panic!("Invalid IP4P values: {:?}", ip4p_resolve);
+    }
+    let port = u16::from_str_radix(ip4p_resolve[2], 16).expect("Invalid port value");
+    let ipab = u16::from_str_radix(ip4p_resolve[3], 16).expect("Invalid ipab value");
+    let ipcd = u16::from_str_radix(ip4p_resolve[4], 16).expect("Invalid ipcd value");
+    
+    let ipa = ipab >> 8;
+    let ipb = ipab & 0xff;
+    let ipc = ipcd >> 8;
+    let ipd = ipcd & 0xff;
+
+    let remote_addr = SocketAddr::new(
+        Ipv4Addr::new(ipa.try_into().unwrap(), ipb.try_into().unwrap(), ipc.try_into().unwrap(), ipd.try_into().unwrap()).into(),
+        port.try_into().unwrap()
+    );
+    return remote_addr;
 }

--- a/phantun/src/utils.rs
+++ b/phantun/src/utils.rs
@@ -71,7 +71,7 @@ pub async fn lookup_host(domain: &str, ip4p_resolve: bool, ipv4_only: bool) -> s
 }
 
 fn resolve_ip4p_domain(domain: &str) -> std::net::SocketAddr {
-    let ip4p_addr = dns_lookup::lookup_host(domain).unwrap();
+    let ip4p_addr = dns_lookup::lookup_host(domain.trim_end_matches(":0")).unwrap();
     let ip4p_addr = ip4p_addr[0].to_string();
     let ip4p_resolve: Vec<&str> = ip4p_addr.split(':').collect();
     if ip4p_resolve.len() != 5 {


### PR DESCRIPTION
[IP4P](https://github.com/heiher/natmap?tab=readme-ov-file#ip4p-address) is a method proposed by the open-source project natmap, which uses AAAA records to transmit encoded IPv4 addresses and ports. With IP4P domain resolution, users can easily achieve network penetration in NAT1 environments and perform UDP obfuscation using natmap and phantun.

This request has preliminarily implemented IP4P resolution with the help of AI tools, although the code quality may not be optimal.