### PR TITLE
Update README to include incoming interface (-i tun0) in client NAT commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ both IPv4 and IPv6 usage.
 #### Using iptables
 
 ```
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
+ip6tables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
 ```
 
 [Back to TOC](#table-of-contents)


### PR DESCRIPTION
This PR updates the README to include the `-i tun0` option in iptables and ip6tables commands. The change ensures NAT rules apply only to traffic from the `tun0` interface on the Phantun client host.

Updated Commands:


```sh
iptables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
ip6tables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
```