### PR TITLE
Revert "Update README to include incoming interface (-i tun0) in client NAT commands"

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ both IPv4 and IPv6 usage.
 #### Using iptables
 
 ```
-iptables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
-ip6tables -t nat -A POSTROUTING -o eth0 -i tun0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 ```
 
 [Back to TOC](#table-of-contents)


### PR DESCRIPTION
Reverts dndx/phantun#163

The `-i` option won't work with `POSTROUTING`, the following error occurs:

```
iptables v1.8.9 (nf_tables): Can't use -i with POSTROUTING
```