### PR TITLE
add some release options to optimize the size of the binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,10 @@ members = [
     "fake-tcp",
     "phantun",
 ]
+
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
When using an OpenWrt router, I am concerned about the size of the binary. Based on the recommendations from <https://github.com/johnthagen/min-sized-rust>, I have added some compile-time options to optimize the binary size. The optimized binary has been successfully tested on a real OpenWrt device, and everything is running smoothly.