### PR TITLE
Fix UDP source ip

### DIFF
--- a/phantun/Cargo.toml
+++ b/phantun/Cargo.toml
@@ -19,6 +19,6 @@ pretty_env_logger = "0"
 tokio-tun = "0"
 num_cpus = "1"
 neli = "0"
-nix = { version = "0", features = ["net"] }
+nix = { version = "0", features = ["net", "uio", "socket"] }
 tokio = { workspace = true }
 log = { workspace = true }

--- a/phantun/src/utils.rs
+++ b/phantun/src/utils.rs
@@ -10,7 +10,8 @@ use neli::{
     types::RtBuffer,
     utils::Groups,
 };
-use std::net::{Ipv6Addr, SocketAddr};
+use nix::sys::socket::{CmsgIterator, ControlMessageOwned, SockaddrLike as _};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use tokio::net::UdpSocket;
 
 pub fn new_udp_reuseport(local_addr: SocketAddr) -> UdpSocket {
@@ -28,9 +29,82 @@ pub fn new_udp_reuseport(local_addr: SocketAddr) -> UdpSocket {
     // from tokio-rs/mio/blob/master/src/sys/unix/net.rs
     udp_sock.set_cloexec(true).unwrap();
     udp_sock.set_nonblocking(true).unwrap();
+
+    // enable IP_PKTINFO/IPV6_PKTINFO delivery so we know the destination address of incoming
+    // packets
+    if local_addr.is_ipv4() {
+        nix::sys::socket::setsockopt(&udp_sock, nix::sys::socket::sockopt::Ipv4PacketInfo, &true)
+            .unwrap();
+    } else {
+        nix::sys::socket::setsockopt(
+            &udp_sock,
+            nix::sys::socket::sockopt::Ipv6RecvPacketInfo,
+            &true,
+        )
+        .unwrap();
+    }
+
     udp_sock.bind(&socket2::SockAddr::from(local_addr)).unwrap();
     let udp_sock: std::net::UdpSocket = udp_sock.into();
     udp_sock.try_into().unwrap()
+}
+
+pub async fn udp_recv_pktinfo(
+    sock: &UdpSocket,
+    buf: &mut [u8],
+) -> std::io::Result<(usize, std::net::SocketAddr, std::net::IpAddr)> {
+    use std::os::unix::io::AsRawFd;
+    use tokio::io::Interest;
+    use nix::sys::socket::cmsg_space;
+
+    sock.async_io(Interest::READABLE, || {
+        let control_buffer_size = std::cmp::max(
+            cmsg_space::<nix::libc::in_pktinfo>(),
+            cmsg_space::<nix::libc::in6_pktinfo>(),
+        );
+        let mut control_buffer = vec![0u8; control_buffer_size];
+        let iov = &mut [std::io::IoSliceMut::new(buf)];
+        let res = nix::sys::socket::recvmsg::<nix::sys::socket::SockaddrStorage>(
+            sock.as_raw_fd(),
+            iov,
+            Some(&mut control_buffer),
+            nix::sys::socket::MsgFlags::empty(),
+        )?;
+
+        let src_addr = res.address.expect("missing source address");
+        let src_addr: SocketAddr = {
+            if let Some(inaddr) = src_addr.as_sockaddr_in() {
+                SocketAddrV4::new(inaddr.ip(), inaddr.port()).into()
+            } else if let Some(in6addr) = src_addr.as_sockaddr_in6() {
+                SocketAddrV6::new(
+                    in6addr.ip(),
+                    in6addr.port(),
+                    in6addr.flowinfo(),
+                    in6addr.scope_id(),
+                )
+                .into()
+            } else {
+                panic!("unexpected source address family {:#?}", src_addr.family());
+            }
+        };
+
+        let dst_addr = dst_addr_from_cmsgs(res.cmsgs()?).expect("didn't receive pktinfo");
+
+        Ok((res.bytes, src_addr, dst_addr))
+    })
+    .await
+}
+
+fn dst_addr_from_cmsgs(cmsgs: CmsgIterator) -> Option<IpAddr> {
+    for cmsg in cmsgs {
+        if let ControlMessageOwned::Ipv4PacketInfo(pktinfo) = cmsg {
+            return Some(Ipv4Addr::from(pktinfo.ipi_addr.s_addr.to_ne_bytes()).into());
+        }
+        if let ControlMessageOwned::Ipv6PacketInfo(pktinfo) = cmsg {
+            return Some(Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr).into());
+        }
+    }
+    None
 }
 
 pub fn assign_ipv6_address(device_name: &str, local: Ipv6Addr, peer: Ipv6Addr) {


### PR DESCRIPTION
Extract the destination IP address from incoming UDP packets, and use bind the local sockets to it to ensure we always reply from the same source as remote UDP peer used as destination to contact us. See #177 for concrete example of the problem.

I've tested this in following scenarios:

* Ordinary global IPv6 addresses with privacy extensions enabled to ensure the problem described in #177 is actually fixed.
* Link-local IPv6 addresses to ensure that the scope id is properly handled.
* IPv4-mapped IPv6 address  (i.e. the server listens on `[::]:51820`, but the UDP peer "connects" over IPv4)
* Native IPv4

Closes #177