### PR TITLE
Follow up changes in rand 0.9.0

### DIFF
--- a/fake-tcp/src/lib.rs
+++ b/fake-tcp/src/lib.rs
@@ -402,7 +402,7 @@ impl Stack {
     /// Connects to the remote end. `None` returned means
     /// the connection attempt failed.
     pub async fn connect(&mut self, addr: SocketAddr) -> Option<Socket> {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         for local_port in rng.gen_range(32768..=60999)..=60999 {
             let local_addr = SocketAddr::new(
                 if addr.is_ipv4() {


### PR DESCRIPTION
In rand 0.9.0 (2025-01-27), `SeedableRng::from_entropy` has been renamed to `from_os_rng`. This change will lead to build error, and this commit fixed it.  See also: https://github.com/rust-random/rand/blob/0bc3f652c4500406b343a517e058caedd1f095a9/rand_core/CHANGELOG.md?plain=1#L19